### PR TITLE
Message name not matching documentation Edit

### DIFF
--- a/app.js
+++ b/app.js
@@ -32,8 +32,8 @@ io.sockets.on('connection', function (socket) {
   socket.on('next', function(){
       io.sockets.in(hash).emit('next');
   });
-  socket.on('prev', function(){
-      io.sockets.in(hash).emit('prev');
+  socket.on('previous', function(){
+      io.sockets.in(hash).emit('previous');
   });
   socket.on('camera', function(){
       io.sockets.in(hash).emit('camera');


### PR DESCRIPTION
The 'previous' socket.io message is written just 'prev' in the code, making the steps on 'How to Use' not work.
